### PR TITLE
fix: upgrade ua-parser-js to 0.7.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "react-dom": "16.9.0"
   },
   "dependencies": {
-    "ua-parser-js": "0.7.20"
+    "ua-parser-js": "^0.7.24"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7291,10 +7291,10 @@ typescript@>=2.8.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.1.tgz#0b7a04b8cf3868188de914d9568bd030f0c56192"
   integrity sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==
 
-ua-parser-js@0.7.20:
-  version "0.7.20"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
-  integrity sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==
+ua-parser-js@^0.7.24:
+  version "0.7.24"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.24.tgz#8d3ecea46ed4f1f1d63ec25f17d8568105dc027c"
+  integrity sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
ua-parser-js has ReDOS vulnerability that is fixed in 0.7.24.

https://app.snyk.io/vuln/npm:ua-parser-js